### PR TITLE
generate_pages.py: Ported to work with GitHub release assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: PR Checks
+on: push
+
+env:
+  CI_IMAGE: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-debian:10-master-132813612
+
+jobs:
+  docs:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+    - name: Generate website
+      run: |
+
+        cat << EOF > builddocs.sh
+        #!/bin/bash
+
+        # Install deps
+        pip3 install pygithub
+
+        # Build the docs website
+        python3 generate_pages.py
+        EOF
+
+        chmod +x builddocs.sh
+
+        docker run \
+              --privileged \
+              --device /dev/fuse \
+              --env API_TOKEN \
+              --volume /home/runner/work:/__w \
+              --workdir /__w/docs-website/docs-website \
+              $CI_IMAGE \
+              ./builddocs.sh
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: docs
+        path: public

--- a/generate_pages.py
+++ b/generate_pages.py
@@ -1,53 +1,48 @@
 #!/usr/bin/env python3
-"""Download and deploy the latest BuildStream docs."""
-
-import logging
 import os
+import logging
 import re
-from itertools import groupby
+import itertools
+import urllib.request
+import urllib.error
+import tarfile
 from typing import NamedTuple
+from github import Github
 from pathlib import Path
-from zipfile import ZipFile
-
-import gitlab
 
 
-GITLAB_SERVER = "https://gitlab.com"
-PROJECT = "buildstream/buildstream"
+GITHUB_ORG_NAME = "buildstream-migration"
+GITHUB_PROJECT = "buildstream"
+GITHUB_API_TOKEN = os.getenv("API_TOKEN")
+
+WORK_DIR = Path.cwd() / "work"
 OUTPUT_DIR = Path.cwd() / "public"
+os.makedirs(WORK_DIR, exist_ok=True)
+os.makedirs(OUTPUT_DIR, exist_ok=True)
 
 
 def main():
-    """Query and download the latest pieces of BuildStream documentation."""
     logging.basicConfig(level=logging.INFO)
 
-    downloaded_versions = download_docs()
+    git = Github(GITHUB_API_TOKEN)
+    org = git.get_organization(GITHUB_ORG_NAME)
+    repo = org.get_repo(GITHUB_PROJECT)
 
-    # Now we can extract the docs
-    for version in downloaded_versions:
-        # The directory in which our docs should end up
-        doc_dir = OUTPUT_DIR / str(version)
-        # The zipfile containing our docs
-        doc_zip = OUTPUT_DIR / (str(version) + ".zip")
+    # Query github and find out which GitRelease objects we're interested in.
+    #
+    stable_releases, dev_snapshots = select_releases(repo)
 
-        # Unzip the zipfile
-        doc_dir.mkdir(parents=True)
-        with ZipFile(doc_zip) as doc:
-            doc.extractall(doc_dir)
-        doc_zip.unlink()
+    # Download the docs and extract them into the site directory for
+    # each github GitRelease we're interested in.
+    #
+    for version, release in stable_releases + dev_snapshots:
+        download_and_extract_docs(version, release)
 
-        # Move the docs to the directory they're expected in
-        for path in doc_dir.glob("public/*"):
-            path.rename(doc_dir / path.name)
-
-    # Finally, update the doc links
+    # Format the template
+    #
     version_tag = '<li class="toctree-l1"><a class="reference internal" href="{version}/index.html">{version}</a></li>'
-
-    # Currently, stable versions are all even minor versions
-    stable = "\n".join(version_tag.format(version=v)
-                       for v in downloaded_versions if v != "master" and v.minor % 2 == 0)
-    snapshot = "\n".join(version_tag.format(version=v)
-                         for v in downloaded_versions if v == "master" or v.minor % 2 == 1)
+    stable = "\n".join(version_tag.format(version=v) for v, _ in stable_releases)
+    snapshot = "\n".join(version_tag.format(version=v) for v, _ in dev_snapshots)
 
     with open("index.html.tmpl") as index:
         template = index.read()
@@ -56,61 +51,157 @@ def main():
         index.write(template.format(stable_versions=stable, snapshot_versions=snapshot))
 
 
-def download_docs():
-    """Query and download the latest pieces of BuildStream documentation."""
-    token = os.getenv("API_TOKEN")
-    server = gitlab.Gitlab(GITLAB_SERVER, private_token=token)
-    project = server.projects.get(PROJECT)
+def select_releases(repo):
+    """"Iterates over all the releases and selects the latest releases
 
-    downloaded_versions = []
+    Args:
+       repo (GitRepo): The GitRepo to query for releases
 
-    # First, get a nicely ordered list of all minor versions
-    tags = get_semver_tags(project)
-    minor_groups = group_tags_by_minor_versions(tags)
-    num_groups = 0
+    Returns:
+       (list): A list of (Semver, GitRelease) tuples for each selected stable release
+       (list): A list of (Semver, GitRelease) tuples for each selected dev snapshot
+    """
+    releases = {}
 
-    # Next, find the latest patch version with documentation we can
-    # publish and publish that documentation
-    for group in minor_groups:
-        num_groups += 1
-        # group is a tuple of a string containing the version number
-        # truncated at the minor version, and a collection of tuples
-        # of semver versions and their tags that match this minor
-        # version.
-        #
-        # E.g. ("1.2", [(Semver(1, 2, 0), <python-gitlab tag object>)])
-        # *note that the collection is not a list, but a generator*
-        #
-        # We iterate over this in reverse order so that we pull in the
-        # latest docs for the given minor version.
-        versions = sorted(group[1], reverse=True)
+    # First get all the releases and populate a table of them, indexed by Semver
+    #
+    for release in repo.get_releases():
+        try:
+            version = Semver.from_string(release.tag_name)
+        except VersionError:
+            # If the Release could not derive the version from the
+            # tag, then it's some kind of invalid noise in the github
+            # releases, just ignore any release not associated to a
+            # Semver formatted release tag.
+            #
+            continue
 
-        for version, tag in versions:
-            commit = get_tag_commit(project, tag)
-            if download_commit_docs(project, commit, OUTPUT_DIR / (str(version) + ".zip")):
-                downloaded_versions.append(version)
-                break
+        releases[version] = release
 
-            logging.warning("Pipeline unsuccessful for tag %s (commit %s)", version, commit)
+    # Now group the releases by minor point
+    #
+    grouped_releases = group_releases_by_minor_versions(releases)
 
-    # Ensure that we've found docs for exactly every minor version
-    assert num_groups == len(downloaded_versions)
+    # Lets just print out the releases we found
+    #
+    logging.info("Found the following releases:")
+    for group, releases in grouped_releases.items():
+        logging.info("  Group {}.{}".format(group[0], group[1]))
+        for release in releases:
+            logging.info("    Release: {}".format(release[0]))
 
-    # Finally, find the latest commit on master with documentation we
-    # can publish
-    latest = project.commits.list()[0]
-    while latest:
-        if download_commit_docs(project, latest, OUTPUT_DIR / "master.zip"):
-            downloaded_versions.append("master")
-            break
+    # Now lets select which releases we want to use for docs
+    #
+    stable_releases = []
+    dev_snapshots = []
 
-        logging.warning("Pipeline unsuccessful for commit %s - trying previous", latest.short_id)
-        latest = project.commits.get(latest.parent_ids[0])
+    # Build a list of tuples for the latest release of each series,
+    # separated by stable release (even minor point) and dev snapshot (odd minor point)
+    #
+    for group, releases in grouped_releases.items():
 
-    # Ensure that we've found docs for exactly one version of master
-    assert num_groups + 1 == len(downloaded_versions)
+        # If it's a stable release, add the latest one from the group to the list of stable releases,
+        # otherwise append the latest of this dev snapshot to the list of snapshots
+        if group[1] % 2 == 0:
+            stable_releases.append(releases[-1])
+        else:
+            dev_snapshots.append(releases[-1])
 
-    return downloaded_versions
+    # We only care about publishing the latest dev snapshot, the older
+    # snaphot serieses are not relevant as they will have had stable
+    # releases by now.
+    #
+    dev_snapshot = dev_snapshots[-1]
+
+    # Lets print what we've selected
+    #
+    logging.info("\nSelected the following stable releases:")
+    for release_version, _ in stable_releases:
+        logging.info("  Release: {}".format(release_version))
+
+    logging.info("\nSelected the following dev snapshot:")
+    logging.info("  Snapshot: {}".format(dev_snapshot[0]))
+
+    return stable_releases, [ dev_snapshot ]
+
+
+def group_releases_by_minor_versions(releases):
+    """Get the set of latest minor versions.
+
+    Args:
+       releases (dict): A dictionary of GitRelease objects, indexed by Semver object
+
+    Returns:
+       (dict): A dictionary of sorted lists of the format [(Semver, GitRelease)], indexed by
+               (int, int) major/minor point version tuples.
+
+    Because python guarantees the preservation of the order of dictionary keys
+    by their insertion order, the returned dictionary is also guaranteed to be
+    sorted from lowest release to greatest release.
+
+    The lists of releases per major/minor point tuple are also sorted, the
+    last item in each list is the latest release for the given set.
+    """
+
+    # Change this dictionary into a list of tuples of (Semver, GitRelease)
+    releases = releases.items()
+
+    # Lets sort the tuples by Semver
+    releases = sorted(releases)
+
+    # Create groups for minor versions, this will give us a list of tuples, where
+    # the first element is a major.minor point version (group) and the second
+    # tuple element is the list of (Semver, GitRelease) tuples associated to that
+    # version.
+    #
+    groups = itertools.groupby(releases, lambda item: (item[0].major, item[0].minor))
+
+    # Now lets construct a new dictionary of these groups, and sort the lists for
+    # a more convenient return.
+    #
+    grouped_releases = {}
+    for group in groups:
+        group_version = group[0]
+        group_versions = group[1]
+        grouped_releases[group_version] = sorted(group_versions)
+
+    return grouped_releases
+
+
+def download_and_extract_docs(version, release):
+    """Downloads and extracts the documentation for the given release.
+
+    Args:
+       version (Semver): The version we're extracting docs for
+       release (GitRelease): The github release object
+    """
+    logging.info("Downloading docs for version: {}".format(version))
+
+    download_path = os.path.join(WORK_DIR, "docs-{}.tgz".format(version))
+    extract_path = os.path.join(OUTPUT_DIR, str(version))
+
+    for asset in release.get_assets():
+        if asset.name == "docs.tgz":
+            download_asset(asset.browser_download_url, download_path)
+
+    if not os.path.exists(download_path):
+        logging.error("Could not download docs for version: {}".format(version))
+
+    with tarfile.open(download_path, "r:*") as tar:
+        tar.extractall(path=extract_path)
+
+
+def download_asset(url, filename):
+    logging.info("Downloading {} as {}".format(url, filename))
+    response = urllib.request.urlopen(url)
+    data = response.read()
+    with open(filename, "wb") as f:
+        f.write(data)
+
+
+class VersionError(ValueError):
+    """The version string parsed by Semver is invalid"""
+    pass
 
 
 class Semver(NamedTuple):
@@ -127,66 +218,32 @@ class Semver(NamedTuple):
         if match:
             return Semver(*(int(num) for num in match.groups()))
 
-        raise ValueError(f"'{string}' is not a valid semver string")
+        raise VersionError(f"'{string}' is not a valid semver string")
 
     @staticmethod
     def match_semver_string(string):
         """Test whether a Semver string is valid."""
-        return re.fullmatch(r"(\d).(\d).(\d)", string)
+        return re.fullmatch(r"(\d+).(\d+).(\d+)", string)
 
-    def __repr__(self):
-        """Print a Semver tuple."""
-        return f"{self.major}.{self.minor}.{self.patch}"
+    def __lt__(self, other):
+        """Compare a Semver to another Semver for sorting purposes"""
+        if self.major < other.major:
+            # Lower major point
+            return True
+        elif self.major == other.major:
+            if self.minor < other.minor:
+                # Equal major point and lower minor point
+                return True
+            elif self.minor == other.minor:
+                if self.patch < other.patch:
+                    # Equal major and minor point, lower patch level.
+                    return True
 
-
-def get_semver_tags(project):
-    """Get a mapping between of tags and their semantic versions."""
-    tags = project.tags.list(all=True)
-
-    tags = [tag for tag in tags if Semver.match_semver_string(tag.name)]
-    return {Semver.from_string(tag.name): tag for tag in tags}
-
-
-def group_tags_by_minor_versions(tags):
-    """Get the set of latest minor versions."""
-    tags = tags.items()
-    tags = sorted(tags)
-    # Create groups for minor versions
-    return groupby(tags, lambda item: f"{item[0].major}.{item[0].minor}")
-
-
-def get_tag_commit(project, tag):
-    """Get the commit of a given tag."""
-    return project.commits.get(tag.commit["id"])
-
-
-def get_doc_job(commit):
-    """Get the doc job from a commit."""
-
-    # Search for only the "docs" job for a given commit,
-    # there may be more than one "docs" job for the same
-    # commit (pipeline can be run in different ways).
-    #
-    # Return any of these which was successful.
-    #
-    jobs = commit.statuses.list(name="docs")
-
-    for job in jobs:
-        if job.status == "success":
-            return job
-    return None
-
-
-def download_commit_docs(project, commit, filename):
-    """Download the docs for the given commit to the given file path."""
-    job = get_doc_job(commit)
-    if not job:
         return False
 
-    docs = project.jobs.get(job.id)
-    with open(filename, "wb") as output:
-        docs.artifacts(streamed=True, action=output.write)
-    return True
+    def __str__(self):
+        """Print a Semver tuple."""
+        return f"{self.major}.{self.minor}.{self.patch}"
 
 
 if __name__ == "__main__":

--- a/index.html.tmpl
+++ b/index.html.tmpl
@@ -70,18 +70,18 @@
                   <div class="section" id="versions">
                     <h2>Available versions:<a class="headerlink" href="#versions" title="Permalink to this headline">¶</a></h2>
                     <p>If you don't plan on hacking on BuildStream, you most likely want to use the stable versions. These versions are
-                      thoroughly tested and are more suited for our end users, while the master and development snapshots are aimed
+                      thoroughly tested and are more suited for our end users, while the development snapshots are aimed
                       at developers and BuildStream hackers. The development versions might be more prone to bugs or things that have
                       been fixed in subsequent releases.
                     </p>
                     <div style="float: left; width: 50%;">
-                      <p> Stable versions: </p>
+                      <p>Stable versions:</p>
                       <ul>
                         {stable_versions}
                       </ul>
                     </div>
                     <div style="float: right; width: 50%;">
-                      <p> Master and development snapshots:</p>
+                      <p>Development snapshots:</p>
                       <ul>
                         {snapshot_versions}
                       </ul>


### PR DESCRIPTION
Now the site gets generated by downloading docs.tgz files from GitHub
releases rather than using GitLab pipeline artifacts.

Invoking the script now requires setting GITHUB_API_TOKEN instead
of API_TOKEN which was previously used to interact with gitlab.

Since we do not have any support for showing the documentation for
master, this has been removed, and we simply show all of the latest
micro point releases for each stable release, and the latest dev
snapshot.